### PR TITLE
Refactor: Standardize provider verification logic and schema

### DIFF
--- a/pages/admin/dashboard.tsx
+++ b/pages/admin/dashboard.tsx
@@ -9,6 +9,7 @@ interface Provider {
   business_name: string;
   years_experience: number;
   skills: string[];
+  verified: boolean; // Added the verified field
   verification_status: string;
   verification_requested_at: string | null;
   rejection_reason: string | null;

--- a/supabase/functions/send_verification_email.sql
+++ b/supabase/functions/send_verification_email.sql
@@ -80,10 +80,11 @@ BEGIN
 
   -- Update provider status
   UPDATE providers
-  SET 
+  SET
+    verified = (status = 'approved'), -- Set boolean verified flag
     verification_status = status,
-    verification_approved_at = CASE WHEN status = 'approved' THEN NOW() ELSE NULL END,
-    verification_rejected_at = CASE WHEN status = 'rejected' THEN NOW() ELSE NULL END,
+    verification_approved_at = CASE WHEN status = 'approved' THEN NOW() ELSE verification_approved_at END, -- Preserve approval time if already approved
+    verification_rejected_at = CASE WHEN status = 'rejected' THEN NOW() ELSE verification_rejected_at END, -- Preserve rejection time if already rejected
     rejection_reason = reason
   WHERE id = provider_id;
 END;

--- a/supabase/verification.sql
+++ b/supabase/verification.sql
@@ -1,5 +1,6 @@
 -- Add verification status field
 ALTER TABLE providers
+ADD COLUMN IF NOT EXISTS verified BOOLEAN DEFAULT FALSE,
 ADD COLUMN IF NOT EXISTS verification_status text DEFAULT 'pending',
 ADD COLUMN IF NOT EXISTS verification_requested_at timestamptz,
 ADD COLUMN IF NOT EXISTS verification_approved_at timestamptz,
@@ -20,34 +21,3 @@ WITH CHECK (
   auth.uid() = id
   OR auth.role() = 'admin'
 );
-
--- Create admin function to handle verification
-CREATE OR REPLACE FUNCTION handle_provider_verification(
-  provider_id uuid,
-  status text,
-  reason text DEFAULT NULL
-) RETURNS void AS $$
-BEGIN
-  IF status = 'approved' THEN
-    UPDATE providers
-    SET 
-      verified = true,
-      verification_status = 'approved',
-      verification_approved_at = NOW(),
-      verification_rejected_at = NULL,
-      rejection_reason = NULL
-    WHERE id = provider_id;
-  ELSIF status = 'rejected' THEN
-    UPDATE providers
-    SET 
-      verified = false,
-      verification_status = 'rejected',
-      verification_rejected_at = NOW(),
-      rejection_reason = reason
-    WHERE id = provider_id;
-  END IF;
-END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
-
--- Grant execute permission to admin role
-GRANT EXECUTE ON FUNCTION handle_provider_verification TO admin;


### PR DESCRIPTION
- Added `verified` boolean column to `providers` table.
- Consolidated status update logic into `send_verification_email` RPC function, which now sets both `verified` (boolean) and `verification_status` (text).
- Removed redundant `handle_provider_verification` SQL function.
- Updated Provider interface in admin dashboard to include `verified` field.